### PR TITLE
Refactoring part 1

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ extern crate serde_json;
 #[macro_use] extern crate log;
 
 use std::io::Read;
-use std::convert::Into;
+use std::convert::{From, Into, AsRef};
 use std::fmt::{Display, Formatter};
 use std::fmt::Error as FormatterError;
 use url::Url;
@@ -16,21 +16,23 @@ use curl::easy::Easy;
 
 /// Configuration of an oauth2 application.
 pub struct Config {
-    pub client_id: String,
-    pub client_secret: String,
-    pub scopes: Vec<String>,
-    pub auth_url: Url,
-    pub token_url: Url,
-    pub redirect_url: String,
+    client_id: String,
+    client_secret: String,
+    auth_url: Url,
+    token_url: Url,
+    scopes: Vec<String>,
+    response_type: ResponseType,
+    redirect_url: Option<String>,
+    state: Option<String>,
 }
 
 // See https://tools.ietf.org/html/rfc6749#section-5.1
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Deserialize)]
 pub struct Token {
+    pub token_type: String,
     pub access_token: String,
     #[serde(default)]
     pub scopes: Vec<String>,
-    pub token_type: String,
     #[serde(default)]
     pub expires_in: Option<u32>,
     #[serde(default)]
@@ -53,31 +55,98 @@ impl Display for TokenError {
     }
 }
 
+// https://tools.ietf.org/html/rfc6749#section-3.1.1
+pub enum ResponseType {
+    Code,
+    Token,
+    Extension(String),
+}
+
+impl<'a> From<&'a str> for ResponseType {
+    fn from(response_type: &str) -> ResponseType {
+        match response_type {
+            "code" => ResponseType::Code,
+            "token" => ResponseType::Token,
+            extension => ResponseType::Extension(extension.to_string()),
+        }
+    }
+}
+
+impl Display for ResponseType {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), FormatterError> {
+        let formatted = match self {
+            &ResponseType::Code => "code",
+            &ResponseType::Token => "token",
+            &ResponseType::Extension(ref value) => value,
+        };
+
+        write!(f, "{}", formatted)
+    }
+}
+
 impl Config {
-    pub fn new(id: &str, secret: &str, auth_url: &str, token_url: &str) -> Config {
+    pub fn new<I, S, A, T>(client_id: I, client_secret: S, auth_url: A, token_url: T) -> Self
+        where I: Into<String>, S: Into<String>, A: AsRef<str>, T: AsRef<str> {
         Config {
-            client_id: id.to_string(),
-            client_secret: secret.to_string(),
+            client_id: client_id.into(),
+            client_secret: client_secret.into(),
+            auth_url: Url::parse(auth_url.as_ref()).unwrap(),
+            token_url: Url::parse(token_url.as_ref()).unwrap(),
             scopes: Vec::new(),
-            auth_url: Url::parse(auth_url).unwrap(),
-            token_url: Url::parse(token_url).unwrap(),
-            redirect_url: String::new(),
+            response_type: ResponseType::Code,
+            redirect_url: None,
+            state: None,
         }
     }
 
-    pub fn authorize_url(&self, state: String) -> Url {
+    pub fn add_scope<S>(mut self, scope: S) -> Self
+        where S: Into<String> {
+        self.scopes.push(scope.into());
+
+        self
+    }
+
+    pub fn set_response_type<R>(mut self, response_type: R) -> Self
+        where R: Into<ResponseType> {
+        self.response_type = response_type.into();
+
+        self
+    }
+
+    pub fn set_redirect_url<R>(mut self, redirect_url: R) -> Self
+        where R: Into<String> {
+        self.redirect_url = Some(redirect_url.into());
+
+        self
+    }
+
+    pub fn set_state<S>(mut self, state: S) -> Self
+        where S: Into<String> {
+        self.state = Some(state.into());
+
+        self
+    }
+
+    pub fn authorize_url(&self) -> Url {
         let scopes = self.scopes.join(",");
+        let response_type = self.response_type.to_string();
+
         let mut pairs = vec![
             ("client_id", &self.client_id),
-            ("state", &state),
             ("scope", &scopes),
+            ("response_type", &response_type),
         ];
 
-        if self.redirect_url.len() > 0 {
-            pairs.push(("redirect_uri", &self.redirect_url));
+        if let Some(ref redirect_url) = self.redirect_url {
+            pairs.push(("redirect_uri", redirect_url));
+        }
+
+        if let Some(ref state) = self.state {
+            pairs.push(("state", state));
         }
 
         let mut url = self.auth_url.clone();
+
         url.query_pairs_mut().clear().extend_pairs(
             pairs.iter().map(|&(k, v)| { (k, &v[..]) })
         );
@@ -86,7 +155,8 @@ impl Config {
     }
 
     #[deprecated(since="0.4.0", note="please use `exchange_code` instead")]
-    pub fn exchange<C: Into<String>>(&self, code: C) -> Result<Token, String> {
+    pub fn exchange<C>(&self, code: C) -> Result<Token, String>
+        where C: Into<String> {
         let params = vec![
             ("code", code.into())
         ];
@@ -95,7 +165,8 @@ impl Config {
     }
 
     // See https://tools.ietf.org/html/rfc6749#section-4.1.3
-    pub fn exchange_code<C: Into<String>>(&self, code: C) -> Result<Token, String> {
+    pub fn exchange_code<C>(&self, code: C) -> Result<Token, String>
+        where C: Into<String> {
         let params = vec![
             ("grant_type", "authorization_code".to_string()),
             ("code", code.into())
@@ -114,7 +185,8 @@ impl Config {
     }
 
     // See https://tools.ietf.org/html/rfc6749#section-4.3.2
-    pub fn exchange_password<U: Into<String>, P: Into<String>>(&self, username: U, password: P) -> Result<Token, String> {
+    pub fn exchange_password<U, P>(&self, username: U, password: P) -> Result<Token, String>
+        where U: Into<String>, P: Into<String> {
         let params = vec![
             ("grant_type", "password".to_string()),
             ("username", username.into()),
@@ -127,8 +199,9 @@ impl Config {
     fn request_token(&self, mut params: Vec<(&str, String)>) -> Result<Token, String> {
         params.push(("client_id", self.client_id.clone()));
         params.push(("client_secret", self.client_secret.clone()));
-        if self.redirect_url.len() > 0 {
-            params.push(("redirect_uri", self.redirect_url.clone()));
+
+        if let Some(ref redirect_url) = self.redirect_url {
+            params.push(("redirect_uri", redirect_url.to_string()));
         }
 
         let form = url::form_urlencoded::Serializer::new(String::new()).extend_pairs(params).finish();
@@ -174,7 +247,7 @@ impl Config {
 }
 
 impl Token {
-    pub fn from_form(data: Vec<u8>) -> Result<Self, String> {
+    fn from_form(data: Vec<u8>) -> Result<Self, String> {
         let form = url::form_urlencoded::parse(&data);
 
         debug!("reponse: {:?}", form.collect::<Vec<_>>());
@@ -216,7 +289,7 @@ impl Token {
         }
     }
 
-    pub fn from_json(data: Vec<u8>) -> Result<Self, String> {
+    fn from_json(data: Vec<u8>) -> Result<Self, String> {
         let data = String::from_utf8(data).unwrap();
 
         debug!("response: {}", data);

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -4,55 +4,66 @@ extern crate oauth2;
 
 use url::Url;
 use mockito::{mock, SERVER_URL};
-use oauth2::Config;
-
-#[test]
-fn test_new_config() {
-    let config = Config::new("aaa", "bbb", "http://example.com/auth", "http://example.com/token");
-
-    assert_eq!("aaa", config.client_id);
-    assert_eq!("bbb", config.client_secret);
-    assert_eq!(Url::parse("http://example.com/auth").unwrap(), config.auth_url);
-    assert_eq!(Url::parse("http://example.com/token").unwrap(), config.token_url);
-    assert_eq!(0, config.scopes.len());
-    assert_eq!(String::new(), config.redirect_url);
-}
+use oauth2::{Config, ResponseType};
 
 #[test]
 fn test_authorize_url() {
     let config = Config::new("aaa", "bbb", "http://example.com/auth", "http://example.com/token");
-    let url = config.authorize_url(String::new());
 
-    assert_eq!(Url::parse("http://example.com/auth?client_id=aaa&state=&scope=").unwrap(), url);
+    let url = config.authorize_url();
+
+    assert_eq!(Url::parse("http://example.com/auth?client_id=aaa&scope=&response_type=code").unwrap(), url);
 }
 
 #[test]
 fn test_authorize_url_with_scopes() {
-    let mut config = Config::new("aaa", "bbb", "http://example.com/auth", "http://example.com/token");
-    config.scopes.push("read".to_string());
-    config.scopes.push("write".to_string());
+    let config = Config::new("aaa", "bbb", "http://example.com/auth", "http://example.com/token")
+        .add_scope("read")
+        .add_scope("write");
 
-    let url = config.authorize_url(String::new());
+    let url = config.authorize_url();
 
-    assert_eq!(Url::parse("http://example.com/auth?client_id=aaa&state=&scope=read%2Cwrite").unwrap(), url);
+    assert_eq!(Url::parse("http://example.com/auth?client_id=aaa&scope=read%2Cwrite&response_type=code").unwrap(), url);
 }
 
 #[test]
 fn test_authorize_url_with_state() {
-    let config = Config::new("aaa", "bbb", "http://example.com/auth", "http://example.com/token");
-    let url = config.authorize_url("some state".to_string());
+    let config = Config::new("aaa", "bbb", "http://example.com/auth", "http://example.com/token")
+        .set_state("some state");
 
-    assert_eq!(Url::parse("http://example.com/auth?client_id=aaa&state=some+state&scope=").unwrap(), url);
+    let url = config.authorize_url();
+
+    assert_eq!(Url::parse("http://example.com/auth?client_id=aaa&scope=&response_type=code&state=some+state").unwrap(), url);
+}
+
+#[test]
+fn test_authorize_url_with_response_type() {
+    let config = Config::new("aaa", "bbb", "http://example.com/auth", "http://example.com/token")
+        .set_response_type(ResponseType::Token);
+
+    let url = config.authorize_url();
+
+    assert_eq!(Url::parse("http://example.com/auth?client_id=aaa&scope=&response_type=token").unwrap(), url);
+}
+
+#[test]
+fn test_authorize_url_with_extension_response_type() {
+    let config = Config::new("aaa", "bbb", "http://example.com/auth", "http://example.com/token")
+        .set_response_type("code token");
+
+    let url = config.authorize_url();
+
+    assert_eq!(Url::parse("http://example.com/auth?client_id=aaa&scope=&response_type=code+token").unwrap(), url);
 }
 
 #[test]
 fn test_authorize_url_with_redirect_url() {
-    let mut config = Config::new("aaa", "bbb", "http://example.com/auth", "http://example.com/token");
-    config.redirect_url = "http://localhost/redirect".to_string();
+    let config = Config::new("aaa", "bbb", "http://example.com/auth", "http://example.com/token")
+        .set_redirect_url("http://localhost/redirect");
 
-    let url = config.authorize_url(String::new());
+    let url = config.authorize_url();
 
-    assert_eq!(Url::parse("http://example.com/auth?client_id=aaa&state=&scope=&redirect_uri=http%3A%2F%2Flocalhost%2Fredirect").unwrap(), url);
+    assert_eq!(Url::parse("http://example.com/auth?client_id=aaa&scope=&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%2Fredirect").unwrap(), url);
 }
 
 #[test]
@@ -177,6 +188,30 @@ fn test_exchange_password_with_json_response() {
 
     let config = Config::new("aaa", "bbb", "http://example.com/auth", &(SERVER_URL.to_string() + "/token"));
     let token = config.exchange_password("user", "pass");
+
+    mock.assert();
+
+    assert!(token.is_ok());
+
+    let token = token.unwrap();
+    assert_eq!("12/34", token.access_token);
+    assert_eq!("bearer", token.token_type);
+    assert_eq!(vec!["read".to_string(), "write".to_string()], token.scopes);
+    assert_eq!(None, token.expires_in);
+    assert_eq!(None, token.refresh_token);
+}
+
+#[test]
+fn test_exchange_code_successful_with_redirect_url() {
+    let mock = mock("POST", "/token")
+        .match_body("grant_type=authorization_code&code=ccc&client_id=aaa&client_secret=bbb&redirect_uri=http%3A%2F%2Fredirect")
+        .with_body("access_token=12%2F34&token_type=bearer&scope=read,write")
+        .create();
+
+    let config = Config::new("aaa", "bbb", "http://example.com/auth", &(SERVER_URL.to_string() + "/token"))
+        .set_redirect_url("http://redirect");
+
+    let token = config.exchange_code("ccc");
 
     mock.assert();
 


### PR DESCRIPTION
- favour defaults
- for everything else: builder pattern
- make some struct fields private
- relax constraints on arguments by allowing `Into<String>` and `AsRef<str>` where possible
