### PR TITLE
don't clear params

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,7 @@ impl Config {
 
         let mut url = self.auth_url.clone();
 
-        url.query_pairs_mut().clear().extend_pairs(
+        url.query_pairs_mut().extend_pairs(
             pairs.iter().map(|&(k, v)| { (k, &v[..]) })
         );
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -17,6 +17,15 @@ fn test_authorize_url() {
 }
 
 #[test]
+fn test_authorize_url_with_param() {
+    let config = Config::new("aaa", "bbb", "http://example.com/auth?foo=bar", "http://example.com/token");
+
+    let url = config.authorize_url();
+
+    assert_eq!(Url::parse("http://example.com/auth?foo=bar&client_id=aaa&scope=&response_type=code").unwrap(), url);
+}
+
+#[test]
 fn test_authorize_url_with_scopes() {
     let config = Config::new("aaa", "bbb", "http://example.com/auth", "http://example.com/token")
         .add_scope("read")


### PR DESCRIPTION
some authorization URL requires additional params like `https://example.com/login?username=someuser&...` so I'd like to preserve params included in the authorization uri.
Someone may want additional APIs like `add_param`. I'll implement it if you want