### PR TITLE
Include scope in exchange_client_credentials

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,8 +247,10 @@ impl Config {
     /// See https://tools.ietf.org/html/rfc6749#section-4.4.2
     ///
     pub fn exchange_client_credentials(&self) -> Result<Token, TokenError> {
+        let scopes = self.scopes.join(" ");
         let params = vec![
-            ("grant_type", "client_credentials".to_string())
+            ("grant_type", "client_credentials".to_string()),
+            ("scope", scopes),
         ];
 
         self.request_token(params)

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -124,7 +124,7 @@ fn test_exchange_code_successful_with_json_response() {
 #[test]
 fn test_exchange_client_credentials_with_form_response() {
     let mock = mock("POST", "/token")
-        .match_body("grant_type=client_credentials&client_id=aaa&client_secret=bbb")
+        .match_body("grant_type=client_credentials&scope=&client_id=aaa&client_secret=bbb")
         .with_body("access_token=12%2F34&token_type=bearer&scope=read,write")
         .create();
 
@@ -146,7 +146,7 @@ fn test_exchange_client_credentials_with_form_response() {
 #[test]
 fn test_exchange_client_credentials_with_json_response() {
     let mock = mock("POST", "/token")
-        .match_body("grant_type=client_credentials&client_id=aaa&client_secret=bbb")
+        .match_body("grant_type=client_credentials&scope=&client_id=aaa&client_secret=bbb")
         .with_header("content-type", "application/json")
         .with_body("{\"access_token\": \"12/34\", \"token_type\": \"bearer\", \"scopes\": [\"read\", \"write\"]}")
         .create();


### PR DESCRIPTION
In practice, some servers require this, and I think this is what the RFC
intends an oauth client to do.

Fixes #23 