### PR TITLE
Try to parse errors even on non-200 statuses

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,7 +308,11 @@ impl Config {
 
         if code != 200 {
             let reason = String::from_utf8_lossy(data.as_slice());
-            return Err(TokenError::other(format!("expected `200`, found `{}`\nerr: {}", code, reason)))
+            let error = match serde_json::from_str::<TokenError>(&reason) {
+                Ok(error) => error,
+                Err(error) => TokenError::other(format!("couldn't parse json response: {}", error))
+            };
+            return Err(error);
         }
 
         let content_type = easy.content_type().unwrap_or(None).unwrap_or("application/x-www-formurlencoded");


### PR DESCRIPTION
In chapter 5.2 of the spec it says servers should return HTTP 400. Currently everything non-200 is interpreted as an unknown error. I'm working with [dex](https://github.com/coreos/dex/) at the moment, which will correctly return HTTP 400 when it is given an expired code, and the error is not deserialized. I just copied over the error deserialization from the token construction.