### PR TITLE
Add authorize_url_with_state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "oauth2"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Florin Lipan <florinlipan@gmail.com>"]
-version = "1.3.0"
+version = "1.3.1"
 license = "MIT/Apache-2.0"
 description = "Bindings for exchanging OAuth 2 tokens"
 repository = "https://github.com/alexcrichton/oauth2-rs"
@@ -16,3 +16,4 @@ serde_derive = "1.0"
 
 [dev-dependencies]
 mockito = "0.8.2"
+rand = "0.4"

--- a/examples/github.rs
+++ b/examples/github.rs
@@ -15,12 +15,14 @@
 
 extern crate url;
 extern crate oauth2;
+extern crate rand;
 
 use std::env;
 use std::net::TcpListener;
 use std::io::{BufRead, BufReader, Write};
 use url::Url;
 use oauth2::Config;
+use rand::{thread_rng, Rng};
 
 fn main() {
     let github_client_id = env::var("GITHUB_CLIENT_ID").expect("Missing the GITHUB_CLIENT_ID environment variable.");
@@ -39,11 +41,12 @@ fn main() {
     // See below for the server implementation.
     config = config.set_redirect_url("http://localhost:8080");
 
-    // Set the state parameter (optional)
-    config = config.set_state("1234");
+    // Generate a random, per-request state value to prevent CSRF
+    let random: String = thread_rng().gen_ascii_chars().take(16).collect();
+    println!("Generated a random value for state:\n{}\n", random);
 
     // Generate the authorization URL to which we'll redirect the user.
-    let authorize_url = config.authorize_url();
+    let authorize_url = config.authorize_url_with_state(random);
 
     println!("Open this URL in your browser:\n{}\n", authorize_url.to_string());
 

--- a/examples/google.rs
+++ b/examples/google.rs
@@ -15,12 +15,14 @@
 
 extern crate url;
 extern crate oauth2;
+extern crate rand;
 
 use std::env;
 use std::net::TcpListener;
 use std::io::{BufRead, BufReader, Write};
 use url::Url;
 use oauth2::Config;
+use rand::{thread_rng, Rng};
 
 fn main() {
     let google_client_id = env::var("GOOGLE_CLIENT_ID").expect("Missing the GOOGLE_CLIENT_ID environment variable.");
@@ -39,11 +41,12 @@ fn main() {
     // See below for the server implementation.
     config = config.set_redirect_url("http://localhost:8080");
 
-    // Set the state parameter (optional)
-    config = config.set_state("1234");
+    // Generate a random, per-request state value to prevent CSRF
+    let random: String = thread_rng().gen_ascii_chars().take(16).collect();
+    println!("Generated a random value for state:\n{}\n", random);
 
     // Generate the authorization URL to which we'll redirect the user.
-    let authorize_url = config.authorize_url();
+    let authorize_url = config.authorize_url_with_state(random);
 
     println!("Open this URL in your browser:\n{}\n", authorize_url.to_string());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,6 +202,7 @@ impl Config {
     /// Allows setting a state parameter inside the authorization URL, which we'll be returned
     /// by the server after the authorization is over.
     ///
+    #[deprecated(since="1.3.1", note="Pass a random per-request state to authorize_url_with_state() instead")]
     pub fn set_state<S>(mut self, state: S) -> Self
     where S: Into<String> {
         self.state = Some(state.into());
@@ -212,7 +213,20 @@ impl Config {
     ///
     /// Produces the full authorization URL.
     ///
+    /// This method will reuse the same state paramter (if added) each time it is called.  
+    ///
     pub fn authorize_url(&self) -> Url {
+        self.impl_authorize_url(self.state.clone())
+    }
+
+    ///
+    /// Produces the full authorization URL.
+    ///
+    pub fn authorize_url_with_state(&self, state: String) -> Url {
+        self.impl_authorize_url(Some(state))
+    }
+
+    fn impl_authorize_url(&self, state: Option<String>) -> Url {
         let scopes = self.scopes.join(" ");
         let response_type = self.response_type.to_string();
 
@@ -226,7 +240,7 @@ impl Config {
             pairs.push(("redirect_uri", redirect_url));
         }
 
-        if let Some(ref state) = self.state {
+        if let Some(ref state) = state {
             pairs.push(("state", state));
         }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -38,10 +38,15 @@ fn test_authorize_url_with_scopes() {
 
 #[test]
 fn test_authorize_url_with_state() {
+    #[allow(deprecated)]
     let config = Config::new("aaa", "bbb", "http://example.com/auth", "http://example.com/token")
         .set_state("some state");
 
     let url = config.authorize_url();
+
+    assert_eq!(Url::parse("http://example.com/auth?client_id=aaa&scope=&response_type=code&state=some+state").unwrap(), url);
+
+    let url = config.authorize_url_with_state("some state".into());
 
     assert_eq!(Url::parse("http://example.com/auth?client_id=aaa&scope=&response_type=code&state=some+state").unwrap(), url);
 }


### PR DESCRIPTION
As discussed in #28, this adds an `authorize_url_with_state` method which takes ownership of a string to use as the state parameter.  I've deprecated `set_state` and bumped the version to 1.3.1.

I've also updated the examples to generate a random state.  I can back that out or put it in a separate PR if that is preferred.