### PR TITLE
Deprecate set_state() and recommend an upgrade to 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "oauth2"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Florin Lipan <florinlipan@gmail.com>"]
-version = "1.3.0"
+version = "1.3.1"
 license = "MIT/Apache-2.0"
 description = "Bindings for exchanging OAuth 2 tokens"
 repository = "https://github.com/alexcrichton/oauth2-rs"

--- a/examples/github.rs
+++ b/examples/github.rs
@@ -40,7 +40,9 @@ fn main() {
     config = config.set_redirect_url("http://localhost:8080");
 
     // Set the state parameter (optional)
-    config = config.set_state("1234");
+    // Please upgrade to 2.0, this is deprecated because it reuses the same state for every request
+    #[allow(deprecated)]
+    let config = config.set_state("1234");
 
     // Generate the authorization URL to which we'll redirect the user.
     let authorize_url = config.authorize_url();

--- a/examples/google.rs
+++ b/examples/google.rs
@@ -40,7 +40,9 @@ fn main() {
     config = config.set_redirect_url("http://localhost:8080");
 
     // Set the state parameter (optional)
-    config = config.set_state("1234");
+    // Please upgrade to 2.0, this is deprecated because it reuses the same state for every request
+    #[allow(deprecated)]
+    let config = config.set_state("1234");
 
     // Generate the authorization URL to which we'll redirect the user.
     let authorize_url = config.authorize_url();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,9 @@
 //! config = config.set_redirect_url("http://redirect");
 //!
 //! // Set a state parameter (optional, but recommended).
-//! config = config.set_state("1234");
+//! // Please upgrade to 2.0, this is deprecated because it reuses the same state for every request
+//! #[allow(deprecated)]
+//! let config = config.set_state("1234");
 //!
 //! // Generate the full authorization URL.
 //! // This is the URL you should redirect the user to, in order to trigger the authorization process.
@@ -202,6 +204,14 @@ impl Config {
     /// Allows setting a state parameter inside the authorization URL, which we'll be returned
     /// by the server after the authorization is over.
     ///
+    /// *CSRF Protection*
+    ///
+    /// For proper CSRF protection you should set a per-request random state and verify that
+    /// the state matches in the callback.  This API will reuse the same state for every request,
+    /// therefore it is highly recommended that you upgrade to 2.0 and provide a random state
+    /// to the authorize_url() method.
+    ///
+    #[deprecated(since="1.3.1", note="Please upgrade to 2.0 and pass a random per-request state to authorize_url()")]
     pub fn set_state<S>(mut self, state: S) -> Self
     where S: Into<String> {
         self.state = Some(state.into());

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -38,6 +38,7 @@ fn test_authorize_url_with_scopes() {
 
 #[test]
 fn test_authorize_url_with_state() {
+    #[allow(deprecated)]
     let config = Config::new("aaa", "bbb", "http://example.com/auth", "http://example.com/token")
         .set_state("some state");
 


### PR DESCRIPTION
This PR deprecates the set_state() method in the 1.x series and recommends that the developer upgrade to 2.0.  I've bumped the version number to 1.3.1.